### PR TITLE
fixed link for fhashnet

### DIFF
--- a/pub.html
+++ b/pub.html
@@ -222,7 +222,7 @@
 Locality Sensitive Hashing in Fourier Frequency Domain For Soft Set Containment Search
       <br> With Indradyumna Roy, Rishi Agarwal, Soumen Chakrabarti and Anirban Dasgupta
                <br><em>  In NeurIPS, 2023 </em><hll> (Spotlight) </hll>
-        <br>[<a href=https://openreview.net/pdf?id=q3fCWoC9l0><span class="caps">Paper</span></a> |
+        <br>[<a href=https://openreview.net/pdf?id=rUf0GV5CuU><span class="caps">Paper</span></a> |
          <a href=https://github.com/structlearning/fhashnet><span class="caps">Code</span></a>]
 
 <p style="font-size:10px;line-height:5;"></p><p style="font-size:10px;line-height:5;"></p>


### PR DESCRIPTION
The link for the project "Locality Sensitive Hashing in Fourier Frequency Domain For Soft Set Containment Search" is the same as "Efficient Data Subset Selection to Generalize Training Across Models: Transductive and Inductive Networks"